### PR TITLE
Revert "Changed observeOn and subscribeOn threads"

### DIFF
--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/Mjpeg.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/Mjpeg.java
@@ -12,6 +12,7 @@ import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
 import rx.Observable;
+import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
 
 /**
@@ -105,8 +106,8 @@ public class Mjpeg {
      */
     public Observable<MjpegInputStream> open(String url) {
         return connect(url)
-            .subscribeOn(Schedulers.computation())
-            .observeOn(Schedulers.io());
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread());
     }
 
     /**
@@ -119,8 +120,8 @@ public class Mjpeg {
     public Observable<MjpegInputStream> open(String url, int timeout) {
         return connect(url)
             .timeout(timeout, TimeUnit.SECONDS)
-            .subscribeOn(Schedulers.computation())
-            .observeOn(Schedulers.io());
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread());
     }
 
 }


### PR DESCRIPTION
Reverts niqdev/ipcam-view#6

Sorry for reverting the pull-request, but if for example you have no Internet Connection the app will crash so we should use observeOn `AndroidSchedulers.mainThread()`. Can you verify, please?  