### PR TITLE
Added option to send a "Connection: close" header on connection

### DIFF
--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/Mjpeg.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/Mjpeg.java
@@ -34,6 +34,8 @@ public class Mjpeg {
     }
 
     private final Type type;
+    
+    private boolean sendConnectionCloseHeader = false;
 
     private Mjpeg(Type type) {
         if (type == null) {
@@ -77,12 +79,26 @@ public class Mjpeg {
         }
         return this;
     }
+    
+    /**
+     * Send a "Connection: close" header to fix 
+     * <code>java.net.ProtocolException: Unexpected status line</code>
+     * 
+     * @return Observable Mjpeg stream
+     */
+    public Mjpeg sendConnectionCloseHeader() {
+        sendConnectionCloseHeader = true;
+        return this;
+    }
 
     @NonNull
     private Observable<MjpegInputStream> connect(String url) {
         return Observable.defer(() -> {
             try {
                 HttpURLConnection urlConnection = (HttpURLConnection) new URL(url).openConnection();
+                if (sendConnectionCloseHeader) {
+                    urlConnection.setRequestProperty("Connection", "close");
+                }
                 InputStream inputStream = urlConnection.getInputStream();
                 switch (type) {
                     // handle multiple implementations


### PR DESCRIPTION
I had trouble making my pretty-standard D-Link security camera MJPEG stream working. With the basic example provided here, I always got a `java.net.ProtocolException: Unexpected status line` no matter the configuration:

	W/System.err: java.net.ProtocolException: Unexpected status line: 
	W/System.err:     at com.android.okhttp.internal.http.StatusLine.parse(StatusLine.java:54)
	W/System.err:     at com.android.okhttp.internal.http.HttpConnection.readResponse(HttpConnection.java:191)
	W/System.err:     at com.android.okhttp.internal.http.HttpTransport.readResponseHeaders(HttpTransport.java:80)
	W/System.err:     at com.android.okhttp.internal.http.HttpEngine.readNetworkResponse(HttpEngine.java:906)
	W/System.err:     at com.android.okhttp.internal.http.HttpEngine.readResponse(HttpEngine.java:782)
	W/System.err:     at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:463)
	W/System.err:     at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:405)
	W/System.err:     at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getInputStream(HttpURLConnectionImpl.java:243)
	W/System.err:     at com.github.niqdev.mjpeg.Mjpeg.lambda$connect$0(Mjpeg.java:102)
	W/System.err:     at com.github.niqdev.mjpeg.Mjpeg$$Lambda$1.call(Unknown Source)
	W/System.err:     at rx.internal.operators.OnSubscribeDefer.call(OnSubscribeDefer.java:46)
	W/System.err:     at rx.internal.operators.OnSubscribeDefer.call(OnSubscribeDefer.java:35)
	W/System.err:     at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)
	W/System.err:     at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)
	W/System.err:     at rx.Observable.unsafeSubscribe(Observable.java:10144)
	W/System.err:     at rx.internal.operators.OperatorSubscribeOn$1.call(OperatorSubscribeOn.java:94)
	W/System.err:     at rx.internal.schedulers.CachedThreadScheduler$EventLoopWorker$1.call(CachedThreadScheduler.java:230)
	W/System.err:     at rx.internal.schedulers.ScheduledAction.run(ScheduledAction.java:55)
	W/System.err:     at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:428)
	W/System.err:     at java.util.concurrent.FutureTask.run(FutureTask.java:237)
	W/System.err:     at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:272)
	W/System.err:     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
	W/System.err:     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
	W/System.err:     at java.lang.Thread.run(Thread.java:761)

After searching online, I found similar issues (also if not related to MJPEG streams) that has been solved adding a `Connection: close` header to the HTTP request:

* <https://github.com/square/retrofit/issues/805>
* <http://stackoverflow.com/q/28964067/995958>
* <http://stackoverflow.com/a/24303115/995958>

Doing it fixed my issue too. My bet is that my camera, which uses HTTP/1.0, does not support persistent connection (i.e. `Connection: keep-alive`), but the Android HTTP client uses it by default if not explicitly told different.

Hope you'll merge, anyway I hope this PR can help someone else.