### PR TITLE
Changed MjpegInputStreamDefault to handle IllegalArgumentException in parseContentLength

### DIFF
--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegInputStreamDefault.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegInputStreamDefault.java
@@ -101,7 +101,7 @@ public class MjpegInputStreamDefault extends MjpegInputStream {
             if (ContentLengthNew < 0) { // Worst case for finding EOF_MARKER
                 reset();
                 ContentLengthNew = getEndOfSeqeunce(this, EOF_MARKER);
-        }
+            }
         }
         mContentLength = ContentLengthNew;
         reset();


### PR DESCRIPTION
I copied some code from the original SimpleMjpegView's [`MjpegInputStream`](https://bitbucket.org/neuralassembly/simplemjpegview/src/6a5cf5bd8f648f05cff6f4dffdcadb422f99fad5/app/src/main/java/com/camera/simplemjpeg/MjpegInputStream.java?at=master&fileviewer=file-view-default) into your `MjpegInputStreamDefault` implementation.

The reason for this is because I got many `IllegalArgumentException` when parsing frames' content length using your library. When I tested the original SimpleMjpegView these errors went gone, and I noticed it is because the exception is caught and content length is retrieved using a different approach (searching for the end of the frame instead). 

The reason I'm not just using SimpleMjpegView is because I have some trouble in decoding the JPEG frame using its native code, often I got a glitched image from my D-Link security camera. Using your default implementation instead, `BitmapFactory.decodeStream` always works well.

One last note. I don't know why your input stream was different from the original library. I didn't manage to understand if you purposely changed it (in that case I somehow reverted it), and if yes, why you did it. Or if you copied it and later the original library was modified to handle errors similar to mine (in that case I ported those changes here). Please let me know!