### PR TITLE
more reliably stop MjpegViewDefault thread, log exceptions

### DIFF
--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/Mjpeg.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/Mjpeg.java
@@ -2,6 +2,7 @@ package com.github.niqdev.mjpeg;
 
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
+import android.util.Log;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,6 +26,7 @@ import rx.schedulers.Schedulers;
  * </ul>
  */
 public class Mjpeg {
+    private static final String TAG = Mjpeg.class.getSimpleName();
 
     /**
      * Library implementation type
@@ -96,9 +98,11 @@ public class Mjpeg {
         return Observable.defer(() -> {
             try {
                 HttpURLConnection urlConnection = (HttpURLConnection) new URL(url).openConnection();
+                urlConnection.setRequestProperty("Cache-Control", "no-cache");
                 if (sendConnectionCloseHeader) {
                     urlConnection.setRequestProperty("Connection", "close");
                 }
+
                 InputStream inputStream = urlConnection.getInputStream();
                 switch (type) {
                     // handle multiple implementations
@@ -109,6 +113,7 @@ public class Mjpeg {
                 }
                 throw new IllegalStateException("invalid type");
             } catch (IOException e) {
+                Log.e(TAG, "error during connection", e);
                 return Observable.error(e);
             }
         });

--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegInputStreamDefault.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegInputStreamDefault.java
@@ -2,6 +2,7 @@ package com.github.niqdev.mjpeg;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.util.Log;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -17,6 +18,7 @@ import java.util.Properties;
  * https://code.google.com/archive/p/android-camera-axis
  */
 public class MjpegInputStreamDefault extends MjpegInputStream {
+    private static final String TAG = MjpegInputStream.class.getSimpleName();
 
     private final byte[] SOI_MARKER = {(byte) 0xFF, (byte) 0xD8};
     private final byte[] EOF_MARKER = {(byte) 0xFF, (byte) 0xD9};
@@ -37,8 +39,12 @@ public class MjpegInputStreamDefault extends MjpegInputStream {
             c = (byte) in.readUnsignedByte();
             if (c == sequence[seqIndex]) {
                 seqIndex++;
-                if (seqIndex == sequence.length) return i + 1;
-            } else seqIndex = 0;
+                if (seqIndex == sequence.length) {
+                    return i + 1;
+                }
+            } else {
+                seqIndex = 0;
+            }
         }
         return -1;
     }

--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegViewDefault.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegViewDefault.java
@@ -220,7 +220,7 @@ public class MjpegViewDefault extends AbstractMjpegView {
             try {
                 // make sure the thread is not null
                 if (thread != null) {
-                    thread.join(1500);
+                    thread.join(500);
                 }
                 retry = false;
             } catch (InterruptedException e) {

--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegViewDefault.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegViewDefault.java
@@ -8,6 +8,7 @@ import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
 import android.graphics.Typeface;
+import android.util.Log;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
@@ -20,6 +21,7 @@ import java.io.IOException;
  * https://code.google.com/archive/p/android-camera-axis
  */
 public class MjpegViewDefault extends AbstractMjpegView {
+    private static final String TAG = MjpegViewDefault.class.getSimpleName();
 
     private SurfaceHolder.Callback mSurfaceHolderCallback;
     private SurfaceView mSurfaceView;
@@ -27,8 +29,8 @@ public class MjpegViewDefault extends AbstractMjpegView {
     private MjpegViewThread thread;
     private MjpegInputStreamDefault mIn = null;
     private boolean showFps = false;
-    private boolean mRun = false;
-    private boolean surfaceDone = false;
+    private volatile boolean mRun = false;
+    private volatile boolean surfaceDone = false;
     private Paint overlayPaint;
     private int overlayTextColor;
     private int overlayBackgroundColor;
@@ -118,6 +120,10 @@ public class MjpegViewDefault extends AbstractMjpegView {
                 if (surfaceDone) {
                     try {
                         c = mSurfaceHolder.lockCanvas();
+                        if (c == null) {
+                            Log.w(TAG, "null canvas, skipping render");
+                            continue;
+                        }
                         synchronized (mSurfaceHolder) {
                             try {
                                 bm = mIn.readMjpegFrame();
@@ -148,12 +154,15 @@ public class MjpegViewDefault extends AbstractMjpegView {
                                     }
                                 }
                             } catch (IOException e) {
-
+                                Log.e(TAG, "encountered exception during render", e);
                             }
                         }
                     } finally {
-                        if (c != null)
+                        if (c != null) {
                             mSurfaceHolder.unlockCanvasAndPost(c);
+                        } else {
+                            Log.w(TAG, "couldn't unlock surface canvas");
+                        }
                     }
                 }
             }
@@ -204,17 +213,18 @@ public class MjpegViewDefault extends AbstractMjpegView {
     /*
      * @see https://github.com/niqdev/ipcam-view/issues/14
      */
-    void _stopPlayback() {
+    synchronized void _stopPlayback() {
         mRun = false;
         boolean retry = true;
         while (retry) {
             try {
                 // make sure the thread is not null
                 if (thread != null) {
-                    thread.join();
+                    thread.join(1500);
                 }
                 retry = false;
             } catch (InterruptedException e) {
+                Log.e(TAG, "error stopping playback thread", e);
             }
         }
 
@@ -223,6 +233,7 @@ public class MjpegViewDefault extends AbstractMjpegView {
             try {
                 mIn.close();
             } catch (IOException e) {
+                Log.e(TAG, "error closing input stream", e);
             }
             mIn = null;
         }


### PR DESCRIPTION
Was having problems with cleaning up backing activity/fragments when my video feed disconnected due to network problems.  With these changes the backing fragment is garbage collected as expected after being removed.

These changes may be pretty specific to my situation, but I don't anticipate them causing problems for anybody else.

Thanks for your work on the library! 👍 