### PR TITLE
Fix for transparent background color and some additional stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,32 @@ Mjpeg.newInstance()
       mjpegView.showFps(true);
   });
 ```
+<br />
 
-Customize colors
+##### Customize colors
+If you want to get a transparent background for the surface itself (while stream is loading) as well as for the stream background, you need to use the following xml attribute for your MjpegSurfaceView:
 ```java
-mjpegView.setCustomBackgroundColor(Color.TRANSPARENT);
+stream:transparentBackground="true"
+```
+<br />
+You can also set other colors than transparent. Be aware that these colors will only be applied on a running stream. That means you can't change the color of the surface itself which you will see while the stream is loading.
+
+<b>Attention:</b> This only works when ```transparentBackground``` is not set to ```true```. In addition (thanks to SurfaceView) you are not able to directly set transparent background color here.
+
+```java
+mjpegView.setCustomBackgroundColor(Color.DKGRAY);
+```
+```java
+stream:backgroundColor="@android:color/darker_gray"
+```
+<br />
+If you wish to change the colors of the fps overlay you can do it via code.
+
+```java
 mjpegView.setFpsOverlayBackgroundColor(Color.DKGRAY);
 mjpegView.setFpsOverlayTextColor(Color.WHITE);
 ```
+
 
 ### Gradle dependency
 ```

--- a/app/src/main/java/com/github/niqdev/ipcam/IpCamTwoActivity.java
+++ b/app/src/main/java/com/github/niqdev/ipcam/IpCamTwoActivity.java
@@ -51,7 +51,6 @@ public class IpCamTwoActivity extends AppCompatActivity {
             //.open("http://50.244.186.65:8081/mjpg/video.mjpg?COUNTER", TIMEOUT)
             .subscribe(
                 inputStream -> {
-                    mjpegView2.setCustomBackgroundColor(Color.TRANSPARENT);
                     mjpegView2.setFpsOverlayBackgroundColor(Color.DKGRAY);
                     mjpegView2.setFpsOverlayTextColor(Color.WHITE);
                     mjpegView2.setSource(inputStream);

--- a/app/src/main/res/layout/activity_ipcam_two_camera.xml
+++ b/app/src/main/res/layout/activity_ipcam_two_camera.xml
@@ -18,6 +18,7 @@
             android:layout_height="match_parent"
             android:layout_margin="5dp"
             android:layout_weight="1"
+            stream:transparentBackground="false"
             stream:type="stream_default" />
 
         <com.github.niqdev.mjpeg.MjpegSurfaceView
@@ -26,6 +27,8 @@
             android:layout_height="match_parent"
             android:layout_margin="5dp"
             android:layout_weight="1"
+            stream:transparentBackground="false"
+            stream:backgroundColor="@android:color/darker_gray"
             stream:type="stream_default" />
     </LinearLayout>
 

--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegSurfaceView.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegSurfaceView.java
@@ -2,6 +2,7 @@ package com.github.niqdev.mjpeg;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.PixelFormat;
 import android.support.annotation.StyleableRes;
 import android.util.AttributeSet;
 import android.util.SparseArray;
@@ -24,14 +25,25 @@ public class MjpegSurfaceView extends SurfaceView implements SurfaceHolder.Callb
 
     public MjpegSurfaceView(Context context, AttributeSet attrs) {
         super(context, attrs);
+        boolean transparentBackground = getPropertyBoolean(attrs, R.styleable.MjpegSurfaceView, R.styleable.MjpegSurfaceView_transparentBackground);
+        int backgroundColor = getPropertyColor(attrs, R.styleable.MjpegSurfaceView, R.styleable.MjpegSurfaceView_backgroundColor);
+
+        if (transparentBackground) {
+            setZOrderOnTop(true);
+            getHolder().setFormat(PixelFormat.TRANSPARENT);
+        }
 
         switch (getPropertyType(attrs, R.styleable.MjpegSurfaceView, R.styleable.MjpegSurfaceView_type)) {
             case DEFAULT:
-                mMjpegView = new MjpegViewDefault(this, this);
+                mMjpegView = new MjpegViewDefault(this, this, transparentBackground);
                 break;
             case NATIVE:
-                mMjpegView = new MjpegViewNative(this, this);
+                mMjpegView = new MjpegViewNative(this, this, transparentBackground);
                 break;
+        }
+
+        if (mMjpegView != null && backgroundColor != -1) {
+            this.setCustomBackgroundColor(backgroundColor);
         }
     }
 
@@ -42,6 +54,26 @@ public class MjpegSurfaceView extends SurfaceView implements SurfaceHolder.Callb
             int typeIndex = typedArray.getInt(attrIndex, DEFAULT_TYPE);
             Mjpeg.Type type = TYPE.get(typeIndex);
             return type != null ? type : TYPE.get(DEFAULT_TYPE);
+        } finally {
+            typedArray.recycle();
+        }
+    }
+
+    public boolean getPropertyBoolean(AttributeSet attributeSet, @StyleableRes int[] attrs, int attrIndex) {
+        TypedArray typedArray = getContext().getTheme()
+                .obtainStyledAttributes(attributeSet, attrs, 0, 0);
+        try {
+            return typedArray.getBoolean(attrIndex, false);
+        } finally {
+            typedArray.recycle();
+        }
+    }
+
+    public int getPropertyColor(AttributeSet attributeSet, @StyleableRes int[] attrs, int attrIndex) {
+        TypedArray typedArray = getContext().getTheme()
+                .obtainStyledAttributes(attributeSet, attrs, 0, 0);
+        try {
+            return typedArray.getColor(attrIndex, -1);
         } finally {
             typedArray.recycle();
         }

--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegViewDefault.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegViewDefault.java
@@ -27,6 +27,7 @@ public class MjpegViewDefault extends AbstractMjpegView {
 
     private SurfaceHolder.Callback mSurfaceHolderCallback;
     private SurfaceView mSurfaceView;
+    private boolean transparentBackground;
 
     private MjpegViewThread thread;
     private MjpegInputStreamDefault mIn = null;
@@ -61,6 +62,7 @@ public class MjpegViewDefault extends AbstractMjpegView {
         }
 
         private Rect destRect(int bmw, int bmh) {
+
             int tempx;
             int tempy;
             if (displayMode == MjpegViewDefault.SIZE_STANDARD) {
@@ -124,6 +126,7 @@ public class MjpegViewDefault extends AbstractMjpegView {
                 if (surfaceDone) {
                     try {
                         c = mSurfaceHolder.lockCanvas();
+
                         if (c == null) {
                             Log.w(TAG, "null canvas, skipping render");
                             continue;
@@ -139,8 +142,15 @@ public class MjpegViewDefault extends AbstractMjpegView {
                                 _frameCaptured(bm);
                                 destRect = destRect(bm.getWidth(),
                                         bm.getHeight());
-                                c.drawColor(backgroundColor);
+
+                                if (transparentBackground) {
+                                    c.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+                                } else {
+                                    c.drawColor(backgroundColor);
+                                }
+
                                 c.drawBitmap(bm, null, destRect, p);
+
                                 if (showFps) {
                                     p.setXfermode(mode);
                                     if (ovl != null) {
@@ -278,9 +288,10 @@ public class MjpegViewDefault extends AbstractMjpegView {
         }
     }
 
-    MjpegViewDefault(SurfaceView surfaceView, SurfaceHolder.Callback callback) {
+    MjpegViewDefault(SurfaceView surfaceView, SurfaceHolder.Callback callback, boolean transparentBackground) {
         this.mSurfaceView = surfaceView;
         this.mSurfaceHolderCallback = callback;
+        this.transparentBackground = transparentBackground;
         init();
     }
 

--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegViewNative.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegViewNative.java
@@ -23,6 +23,7 @@ public class MjpegViewNative extends AbstractMjpegView {
 
     private SurfaceHolder.Callback mSurfaceHolderCallback;
     private SurfaceView mSurfaceView;
+    private boolean transparentBackground;
 
     private SurfaceHolder holder;
 
@@ -139,7 +140,12 @@ public class MjpegViewNative extends AbstractMjpegView {
 
                         c = mSurfaceHolder.lockCanvas();
                         synchronized (mSurfaceHolder) {
-                            c.drawColor(backgroundColor);
+                            if (transparentBackground) {
+                                c.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+                            } else {
+                                c.drawColor(backgroundColor);
+                            }
+
                             c.drawBitmap(bmp, null, destRect, p);
 
                             if (showFps) {
@@ -268,9 +274,10 @@ public class MjpegViewNative extends AbstractMjpegView {
         }
     }
 
-    MjpegViewNative(SurfaceView surfaceView, SurfaceHolder.Callback callback) {
+    MjpegViewNative(SurfaceView surfaceView, SurfaceHolder.Callback callback, boolean transparentBackground) {
         this.mSurfaceView = surfaceView;
         this.mSurfaceHolderCallback = callback;
+        this.transparentBackground = transparentBackground;
         init();
     }
 

--- a/mjpeg-view/src/main/res/values/attrs.xml
+++ b/mjpeg-view/src/main/res/values/attrs.xml
@@ -2,6 +2,8 @@
 <resources>
     <declare-styleable name="MjpegSurfaceView">
         <attr name="type"/>
+        <attr name="transparentBackground" format="boolean" />
+        <attr name="backgroundColor" format="color" />
     </declare-styleable>
 
     <attr name="type" format="enum">


### PR DESCRIPTION
- Implemented: New xml attribute to make background of SurfaceView as well as the background of the stream (canvas) transparent
- Implemented: New xml attribute to apply the custom background color of the stream (canvas)
- Adjusted: README file contains detailed section about customizing colors and priority between transparent and normal background color now

I tested all this stuff on emulator API 26, real life smartphone API 24 and real life tablet API 22 successfully. I would suggest version 1.3.1 for this minor changes.