### PR TITLE
Fixed gradle build issue

### DIFF
--- a/mjpeg-view/build.gradle
+++ b/mjpeg-view/build.gradle
@@ -40,8 +40,8 @@ dependencies {
     implementation 'com.android.support:support-v4:27.1.1'
     implementation 'com.android.support:support-annotations:27.1.1'
 
-    implementation 'io.reactivex:rxjava:1.3.8'
-    implementation 'io.reactivex:rxandroid:1.2.1'
+    api 'io.reactivex:rxjava:1.3.8'
+    api 'io.reactivex:rxandroid:1.2.1'
 }
 
 apply from: '../bintray.gradle'


### PR DESCRIPTION
The keyword  was changed to  and . In this commit I fixed the rx dependency so it could be accessed from the sample app which do not import directly the rx dependency