### PR TITLE
add setRoate to rotate the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ mjpegView.flipHorizontal(true);
 mjpegView.flipVertical(true);
 ```
 
+To rotate the image
+```java
+mjpegView.setRotate(90);  // degrees
+```
+
 ### Apps that use this library
 * [OpenWebNet Android](https://github.com/openwebnet/openwebnet-android)
 * [TankDroid](https://github.com/bmachek/TankDroid)

--- a/app/src/main/java/com/github/niqdev/ipcam/IpCamDefaultActivity.java
+++ b/app/src/main/java/com/github/niqdev/ipcam/IpCamDefaultActivity.java
@@ -20,6 +20,7 @@ import static com.github.niqdev.ipcam.settings.SettingsActivity.PREF_AUTH_USERNA
 import static com.github.niqdev.ipcam.settings.SettingsActivity.PREF_FLIP_HORIZONTAL;
 import static com.github.niqdev.ipcam.settings.SettingsActivity.PREF_FLIP_VERTICAL;
 import static com.github.niqdev.ipcam.settings.SettingsActivity.PREF_IPCAM_URL;
+import static com.github.niqdev.ipcam.settings.SettingsActivity.PREF_ROTATE_DEGREES;
 
 public class IpCamDefaultActivity extends AppCompatActivity {
 
@@ -66,6 +67,7 @@ public class IpCamDefaultActivity extends AppCompatActivity {
                     mjpegView.setDisplayMode(calculateDisplayMode());
                     mjpegView.flipHorizontal(getBooleanPreference(PREF_FLIP_HORIZONTAL));
                     mjpegView.flipVertical(getBooleanPreference(PREF_FLIP_VERTICAL));
+                    mjpegView.setRotate(Float.parseFloat(getPreference(PREF_ROTATE_DEGREES)));
                     mjpegView.showFps(true);
                 },
                 throwable -> {

--- a/app/src/main/java/com/github/niqdev/ipcam/settings/SettingsActivity.java
+++ b/app/src/main/java/com/github/niqdev/ipcam/settings/SettingsActivity.java
@@ -25,6 +25,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
     public static final String PREF_IPCAM_URL = "com.github.niqdev.ipcam.settings.SettingsActivity.IPCAM_URL";
     public static final String PREF_FLIP_HORIZONTAL = "com.github.niqdev.ipcam.settings.SettingsActivity.FLIP_HORIZONTAL";
     public static final String PREF_FLIP_VERTICAL= "com.github.niqdev.ipcam.settings.SettingsActivity.FLIP_VERTICAL";
+    public static final String PREF_ROTATE_DEGREES = "com.github.niqdev.ipcam.settings.SettingsActivity.ROTATE_DEGREES";
     public static final String PREF_AUTH_USERNAME = "com.github.niqdev.ipcam.settings.SettingsActivity.PREF_AUTH_USERNAME";
     public static final String PREF_AUTH_PASSWORD = "com.github.niqdev.ipcam.settings.SettingsActivity.PREF_AUTH_PASSWORD";
 
@@ -202,6 +203,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             bindPreferenceSummaryToValue(findPreference(PREF_IPCAM_URL));
             bindPreferenceSummaryToValue(findPreference(PREF_FLIP_HORIZONTAL));
             bindPreferenceSummaryToValue(findPreference(PREF_FLIP_VERTICAL));
+            bindPreferenceSummaryToValue(findPreference(PREF_ROTATE_DEGREES));
         }
 
         @Override

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="rotate_degrees_entries">
+        <item>0</item>
+        <item>90</item>
+        <item>180</item>
+        <item>270</item>
+    </string-array>
+    <string-array name="rotate_degrees_entry_values">
+        <item>0</item>
+        <item>90</item>
+        <item>180</item>
+        <item>270</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -18,4 +18,12 @@
         android:key="com.github.niqdev.ipcam.settings.SettingsActivity.FLIP_VERTICAL"
         android:title="Flip image vertically" />
 
+    <ListPreference
+        android:defaultValue="0"
+        android:key="com.github.niqdev.ipcam.settings.SettingsActivity.ROTATE_DEGREES"
+        android:entries="@array/rotate_degrees_entries"
+        android:entryValues="@array/rotate_degrees_entry_values"
+        android:summary="%s"
+        android:title="Rotate image (degrees)" />
+
 </PreferenceScreen>

--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegSurfaceView.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegSurfaceView.java
@@ -125,6 +125,11 @@ public class MjpegSurfaceView extends SurfaceView implements SurfaceHolder.Callb
     }
 
     @Override
+    public void setRotate(float degrees) {
+        mMjpegView.setRotate(degrees);
+    }
+
+    @Override
     public void stopPlayback() {
         mMjpegView.stopPlayback();
     }

--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegView.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegView.java
@@ -16,6 +16,8 @@ public interface MjpegView {
 
     void flipVertical(boolean flip);
 
+    void setRotate(float degrees);
+
     void stopPlayback();
 
     boolean isStreaming();

--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegViewDefault.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegViewDefault.java
@@ -35,6 +35,7 @@ public class MjpegViewDefault extends AbstractMjpegView {
     private boolean showFps = false;
     private boolean flipHorizontal = false;
     private boolean flipVertical = false;
+    private float rotateDegrees = 0;
     private volatile boolean mRun = false;
     private volatile boolean surfaceDone = false;
     private Paint overlayPaint;
@@ -135,12 +136,12 @@ public class MjpegViewDefault extends AbstractMjpegView {
                         }
                         synchronized (mSurfaceHolder) {
                             try {
+                                bm = mIn.readMjpegFrame();
                                 if(flipHorizontal || flipVertical)
-                                {
-                                    bm = flip(mIn.readMjpegFrame());
-                                } else {
-                                    bm = mIn.readMjpegFrame();
-                                }
+                                    bm = flip(bm);
+                                if(rotateDegrees != 0)
+                                    bm = rotate(bm, rotateDegrees);
+
                                 _frameCaptured(bm);
                                 destRect = destRect(bm.getWidth(),
                                         bm.getHeight());
@@ -198,6 +199,14 @@ public class MjpegViewDefault extends AbstractMjpegView {
         m.preScale(sx, sy);
         Bitmap dst = Bitmap.createBitmap(src, 0, 0, src.getWidth(), src.getHeight(), m, false);
         dst.setDensity(DisplayMetrics.DENSITY_DEFAULT);
+        return dst;
+    }
+
+    Bitmap rotate(Bitmap src, float degrees)
+    {
+        Matrix m = new Matrix();
+        m.setRotate(degrees);
+        Bitmap dst = Bitmap.createBitmap(src, 0, 0, src.getWidth(), src.getHeight(), m, false);
         return dst;
     }
 
@@ -396,6 +405,11 @@ public class MjpegViewDefault extends AbstractMjpegView {
     @Override
     public void flipVertical(boolean flip) {
         _flipVertical(flip);
+    }
+
+    @Override
+    public void setRotate(float degrees) {
+        rotateDegrees = degrees;
     }
 
     @Override

--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegViewNative.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegViewNative.java
@@ -381,6 +381,11 @@ public class MjpegViewNative extends AbstractMjpegView {
     }
 
     @Override
+    public void setRotate(float degrees) {
+
+    }
+
+    @Override
     public void stopPlayback() {
         _stopPlayback();
     }


### PR DESCRIPTION
implement #71

* Add `setRoate` method into `MjpegViewDefault`
* Update setting view of the app to set rotation angle (0, 90, 180, 270)

### Example
```java
    private void loadIpCam() {
        Mjpeg.newInstance()
            .credential(getPreference(PREF_AUTH_USERNAME), getPreference(PREF_AUTH_PASSWORD))
            .open(getPreference(PREF_IPCAM_URL), TIMEOUT)
            .subscribe(
                inputStream -> {
                    mjpegView.setSource(inputStream);
                    mjpegView.setDisplayMode(calculateDisplayMode());
                    mjpegView.setRotate(90);  // degrees
                    mjpegView.showFps(true);
                },
                throwable -> {
                    Log.e(getClass().getSimpleName(), "mjpeg error", throwable);
                    Toast.makeText(this, "Error", Toast.LENGTH_LONG).show();
                });
    }
```