### PR TITLE
IllegalArgumentException instead of specific NumberFormatException

### DIFF
--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegInputStreamDefault.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegInputStreamDefault.java
@@ -57,7 +57,7 @@ public class MjpegInputStreamDefault extends MjpegInputStream {
         return (end < 0) ? (-1) : (end - sequence.length);
     }
 
-    private int parseContentLength(byte[] headerBytes) throws IOException, NumberFormatException {
+    private int parseContentLength(byte[] headerBytes) throws IOException, IllegalArgumentException {
         ByteArrayInputStream headerIn = new ByteArrayInputStream(headerBytes);
         Properties props = new Properties();
         props.load(headerIn);
@@ -73,7 +73,7 @@ public class MjpegInputStreamDefault extends MjpegInputStream {
         readFully(header);
         try {
             mContentLength = parseContentLength(header);
-        } catch (NumberFormatException nfe) {
+        } catch (IllegalArgumentException iae) {
             mContentLength = getEndOfSeqeunce(this, EOF_MARKER);
         }
         reset();


### PR DESCRIPTION
My IP-Cam (hardware device) may from Tim eco time send illegal headers in the MJPEG stream.
When this happens, the property list parser used by `parseContentLength` will throw an `IllegalArgumentException` instead of the more specific `NumberFormatException`.

This PR replaces the handling and makes the library usable again for me.