### PR TITLE
increase maximum frame size to support newer cameras

### DIFF
--- a/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegInputStreamDefault.java
+++ b/mjpeg-view/src/main/java/com/github/niqdev/mjpeg/MjpegInputStreamDefault.java
@@ -18,7 +18,7 @@ import java.util.Properties;
  */
 public class MjpegInputStreamDefault extends MjpegInputStream {
     private final static int HEADER_MAX_LENGTH = 100;
-    private final static int FRAME_MAX_LENGTH = 40000 + HEADER_MAX_LENGTH;
+    private final static int FRAME_MAX_LENGTH = 200000 + HEADER_MAX_LENGTH;
     private final byte[] SOI_MARKER = {(byte) 0xFF, (byte) 0xD8};
     private final byte[] EOF_MARKER = {(byte) 0xFF, (byte) 0xD9};
     private final String CONTENT_LENGTH = "Content-Length";


### PR DESCRIPTION
Increase maximum frame size from 40,000 bytes to 200,000 bytes to support newer high resolution cameras which can produce larger frames.

Without this change in place the parser fails to detect the start and end frame markers if the frame size happens to be larger than 40,000 bytes.

Surely there is a better way of doing this, but this was the easiest way to get around the problem.