### PR TITLE
Move namespace

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,11 +24,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
-    lintOptions {
-        disable 'InvalidPackage'
+    lint {
         abortOnError false
+        disable 'InvalidPackage'
     }
+    namespace 'com.github.niqdev.ipcam'
+
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.github.niqdev.ipcam">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/mjpeg-view/build.gradle
+++ b/mjpeg-view/build.gradle
@@ -18,10 +18,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
     packagingOptions {
-        exclude 'META-INF/services/javax.annotation.processing.Processor'
+        resources {
+            excludes += ['META-INF/services/javax.annotation.processing.Processor']
+        }
     }
+
 
     useLibrary 'org.apache.http.legacy'
 
@@ -30,6 +32,7 @@ android {
             path 'src/main/jni/Android.mk'
         }
     }
+    namespace 'com.github.niqdev.mjpeg'
 }
 
 dependencies {

--- a/mjpeg-view/src/main/AndroidManifest.xml
+++ b/mjpeg-view/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest
-    package="com.github.niqdev.mjpeg"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
